### PR TITLE
Fix Entities references for rendering engine

### DIFF
--- a/dicom_viewer_winform/RenderEngine/RenderEngine.vcxproj
+++ b/dicom_viewer_winform/RenderEngine/RenderEngine.vcxproj
@@ -118,6 +118,11 @@
     <Reference Include="System.Data.Linq" />
     <Reference Include="System.Xml" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\dicom_viewer_winform\Entities\Entities.csproj">
+      <Project>{197DD6A4-5EC4-4BA2-A8DF-078FE0C21303}</Project>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets" />
 </Project>

--- a/dicom_viewer_winform/dicom_viewer_winform.sln
+++ b/dicom_viewer_winform/dicom_viewer_winform.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "dicom_viewer_winform", "dic
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "RenderEngine", "RenderEngine\RenderEngine.vcxproj", "{052AFDD0-10BE-4B76-A594-01F778DFE8FF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Entities", "dicom_viewer_winform\Entities\Entities.csproj", "{197DD6A4-5EC4-4BA2-A8DF-078FE0C21303}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -30,8 +32,14 @@ Global
 		{052AFDD0-10BE-4B76-A594-01F778DFE8FF}.Release|Any CPU.ActiveCfg = Release|x64
 		{052AFDD0-10BE-4B76-A594-01F778DFE8FF}.Release|Any CPU.Build.0 = Release|x64
 		{052AFDD0-10BE-4B76-A594-01F778DFE8FF}.Release|x64.ActiveCfg = Release|x64
-		{052AFDD0-10BE-4B76-A594-01F778DFE8FF}.Release|x64.Build.0 = Release|x64
-	EndGlobalSection
+                {052AFDD0-10BE-4B76-A594-01F778DFE8FF}.Release|x64.Build.0 = Release|x64
+                {197DD6A4-5EC4-4BA2-A8DF-078FE0C21303}.Debug|Any CPU.ActiveCfg = Debug|x64
+                {197DD6A4-5EC4-4BA2-A8DF-078FE0C21303}.Debug|x64.ActiveCfg = Debug|x64
+                {197DD6A4-5EC4-4BA2-A8DF-078FE0C21303}.Debug|x64.Build.0 = Debug|x64
+                {197DD6A4-5EC4-4BA2-A8DF-078FE0C21303}.Release|Any CPU.ActiveCfg = Release|x64
+                {197DD6A4-5EC4-4BA2-A8DF-078FE0C21303}.Release|x64.ActiveCfg = Release|x64
+                {197DD6A4-5EC4-4BA2-A8DF-078FE0C21303}.Release|x64.Build.0 = Release|x64
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/dicom_viewer_winform/dicom_viewer_winform/DataSetSelector.cs
+++ b/dicom_viewer_winform/dicom_viewer_winform/DataSetSelector.cs
@@ -1,4 +1,4 @@
-using dicom_viewer_winform.Entities;
+using Entities;
 using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using System.Globalization;

--- a/dicom_viewer_winform/dicom_viewer_winform/DicomViewerForm.Designer.cs
+++ b/dicom_viewer_winform/dicom_viewer_winform/DicomViewerForm.Designer.cs
@@ -1,4 +1,4 @@
-﻿namespace dicom_viewer_winform
+namespace dicom_viewer_winform
 {
     partial class DicomViewerForm
     {

--- a/dicom_viewer_winform/dicom_viewer_winform/DicomViewerForm.cs
+++ b/dicom_viewer_winform/dicom_viewer_winform/DicomViewerForm.cs
@@ -23,7 +23,7 @@ namespace dicom_viewer_winform
                 var loader = new DataSetSelector();
                 loader.Open(dialog.SelectedPath);
 
-                var firstSeries = loader.Series?.FirstOrDefault() as dicom_viewer_winform.Entities.DicomSeries;
+                var firstSeries = loader.Series?.FirstOrDefault() as Entities.DicomSeries;
                 if (firstSeries != null && firstSeries.FileNames.Count > 0)
                 {
                     var middleFile = firstSeries.FileNames[firstSeries.FileNames.Count / 2];

--- a/dicom_viewer_winform/dicom_viewer_winform/DicomVolumeLoader.cs
+++ b/dicom_viewer_winform/dicom_viewer_winform/DicomVolumeLoader.cs
@@ -1,8 +1,8 @@
-﻿using FellowOakDicom;
+using FellowOakDicom;
 using FellowOakDicom.Imaging;
 using FellowOakDicom.Imaging.Codec;
 using FellowOakDicom.Imaging.Render;
-using dicom_viewer_winform.Entities;
+using Entities;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;

--- a/dicom_viewer_winform/dicom_viewer_winform/Entities/Entities.csproj
+++ b/dicom_viewer_winform/dicom_viewer_winform/Entities/Entities.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+  </ItemGroup>
+</Project>

--- a/dicom_viewer_winform/dicom_viewer_winform/MprRenderer.cs
+++ b/dicom_viewer_winform/dicom_viewer_winform/MprRenderer.cs
@@ -2,7 +2,7 @@ using System;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.Runtime.InteropServices;
-using dicom_viewer_winform.Entities;
+using Entities;
 
 namespace dicom_viewer_winform
 {

--- a/dicom_viewer_winform/dicom_viewer_winform/MprViewerForm.cs
+++ b/dicom_viewer_winform/dicom_viewer_winform/MprViewerForm.cs
@@ -1,6 +1,6 @@
 using System.Drawing;
 using System.Windows.Forms;
-using dicom_viewer_winform.Entities;
+using Entities;
 
 namespace dicom_viewer_winform
 {

--- a/dicom_viewer_winform/dicom_viewer_winform/MprVtkViewerForm.cs
+++ b/dicom_viewer_winform/dicom_viewer_winform/MprVtkViewerForm.cs
@@ -2,7 +2,7 @@ using System.Drawing;
 using System.Drawing.Imaging;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
-using dicom_viewer_winform.Entities;
+using Entities;
 using RenderEngine;
 
 namespace dicom_viewer_winform

--- a/dicom_viewer_winform/dicom_viewer_winform/Scan.cs
+++ b/dicom_viewer_winform/dicom_viewer_winform/Scan.cs
@@ -1,4 +1,4 @@
-﻿using dicom_viewer_winform.Entities;
+using Entities;
 
 namespace dicom_viewer_winform
 {

--- a/dicom_viewer_winform/dicom_viewer_winform/SimpleDicomSeriesExtractor.cs
+++ b/dicom_viewer_winform/dicom_viewer_winform/SimpleDicomSeriesExtractor.cs
@@ -1,5 +1,5 @@
 using FellowOakDicom;
-using dicom_viewer_winform.Entities;
+using Entities;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/dicom_viewer_winform/dicom_viewer_winform/dicom_viewer_winform.csproj
+++ b/dicom_viewer_winform/dicom_viewer_winform/dicom_viewer_winform.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
@@ -13,6 +13,14 @@
     <PackageReference Include="fo-dicom" Version="5.2.2" />
     <PackageReference Include="fo-dicom.Imaging.Desktop" Version="5.2.2" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\dicom_viewer_winform\Entities\Entities.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="Entities\**\*.cs" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- add Entities class library for WinForms solution
- reference Entities project from WinForms app and rendering engine
- update namespaces that referenced `dicom_viewer_winform.Entities`

## Testing
- `dotnet build dicom_viewer_winform/dicom_viewer_winform.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864d1d5fba4832faa9aa5fa7892d57b