### PR TITLE
Move RenderEngine logic into RenderEngine2

### DIFF
--- a/dicom_viewer_winform/RenderEngine2/Conversions.cpp
+++ b/dicom_viewer_winform/RenderEngine2/Conversions.cpp
@@ -1,0 +1,9 @@
+#include "Conversions.h"
+
+void ConvertMatrix(Matrix^ sourceMatrix, double targetMatrix[16])
+{
+    for (int i = 0; i < 16; i++)
+    {
+        targetMatrix[i] = sourceMatrix[i];
+    }
+}

--- a/dicom_viewer_winform/RenderEngine2/Conversions.h
+++ b/dicom_viewer_winform/RenderEngine2/Conversions.h
@@ -1,0 +1,6 @@
+#pragma once
+
+using namespace System;
+using namespace Entities;
+
+void ConvertMatrix(Matrix^ sourceMatrix, double targetMatrix[16]);

--- a/dicom_viewer_winform/RenderEngine2/IVisual.cpp
+++ b/dicom_viewer_winform/RenderEngine2/IVisual.cpp
@@ -1,0 +1,1 @@
+#include "IVisual.h"

--- a/dicom_viewer_winform/RenderEngine2/IVisual.h
+++ b/dicom_viewer_winform/RenderEngine2/IVisual.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "ViewportRenderer.h"
+
+namespace RenderEngine2 {
+
+	public interface class IVisual
+	{
+		void PreRender(ViewportRenderer^ viewport);
+		virtual void AddTo(ViewportRenderer^ viewport);
+		virtual void RemoveFrom(ViewportRenderer^ viewport);
+		event System::Action^ Invalidated;
+	};
+}

--- a/dicom_viewer_winform/RenderEngine2/ImageSetReaderFactory.cpp
+++ b/dicom_viewer_winform/RenderEngine2/ImageSetReaderFactory.cpp
@@ -1,0 +1,1 @@
+#include "ImageSetReaderFactory.h"

--- a/dicom_viewer_winform/RenderEngine2/ImageSetReaderFactory.h
+++ b/dicom_viewer_winform/RenderEngine2/ImageSetReaderFactory.h
@@ -1,0 +1,102 @@
+#pragma once
+
+#include "vtkMemoryImageReader.h"
+
+namespace RenderEngine2 {
+
+	ref class ImageSetReaderItem 
+	{
+	public:
+		Entities::ImageSet^ ImageSet;
+		vtkMemoryImageReader* Reader;
+		int RefCount = 0;
+	};
+
+	ref class ImageSetReaderFactory
+	{
+	public:
+		
+		static vtkMemoryImageReader* Acquire(Entities::ImageSet^ imageSet) 
+		{
+			ImageSetReaderItem^ imageSetReaderItem = nullptr;
+
+			for each(auto reader in readers)
+			{
+				if (reader->ImageSet == imageSet)
+				{
+					imageSetReaderItem = reader;
+					break;
+				}
+			}
+
+			if (imageSetReaderItem == nullptr)
+			{
+				imageSetReaderItem = gcnew ImageSetReaderItem();
+				imageSetReaderItem->ImageSet = imageSet;
+				imageSetReaderItem->Reader = vtkMemoryImageReader::New();
+
+				int numberOfImages = imageSet->Slices->Count;
+				int width = imageSet->Slices[0]->Width;
+				int height = imageSet->Slices[0]->Height;
+
+				void** pixels = new void*[imageSet->Slices->Count];
+				int i = 0;
+				for each(auto image in imageSet->Slices)
+				{
+					pixels[i++] = image->Pixels.ToPointer();
+				}
+
+				auto firstImage = imageSet->Slices[0];
+
+				imageSetReaderItem->Reader->SetImages(
+					pixels, 
+					firstImage->BytesPerPixel, 
+					width, 
+					height, 
+					imageSet->Slices->Count, 
+					firstImage->Intercept, 
+					firstImage->Slope, 
+					imageSet->VoxelSpacing->X,
+					imageSet->VoxelSpacing->Y,
+					imageSet->VoxelSpacing->Z,					
+					imageSet->Slices[0]->IsSigned);
+				imageSetReaderItem->Reader->Update();
+
+				readers->Add(imageSetReaderItem);			
+			}
+			imageSetReaderItem->RefCount++;
+			return imageSetReaderItem->Reader;
+		}
+
+		static void Release(Entities::ImageSet^ imageSet)
+		{
+			ImageSetReaderItem^ imageSetReaderItem = nullptr;
+
+			for each(auto reader in readers)
+			{
+				if (reader->ImageSet == imageSet)
+				{
+					imageSetReaderItem = reader;
+					
+					break;
+				}
+			}
+
+			if (imageSetReaderItem != nullptr)
+			{
+				imageSetReaderItem->RefCount--;
+				if (imageSetReaderItem->RefCount == 0)
+				{
+					imageSetReaderItem->Reader->Delete();
+					readers->Remove(imageSetReaderItem);
+				}
+			}
+		}
+		
+	private:
+		
+		static System::Collections::Generic::List<ImageSetReaderItem^>^ readers = gcnew System::Collections::Generic::List<ImageSetReaderItem^>();
+
+	};
+
+}

--- a/dicom_viewer_winform/RenderEngine2/ImageVisual.cpp
+++ b/dicom_viewer_winform/RenderEngine2/ImageVisual.cpp
@@ -1,0 +1,117 @@
+#include "ImageVisual.h"
+
+#include <vtkRenderWindow.h>
+#include <vtkWindowToImageFilter.h>
+#include <vtkImageMapper3D.h>
+#include <vtkImageActor.h>
+#include <vtkImageProperty.h>
+#include <vtkSmartPointer.h>
+#include "vtkMemoryImageReader.h"
+#include "ImageSetReaderFactory.h"
+
+class ImageVisualPrivates
+{
+public:
+	vtkMemoryImageReader* imageReader;
+    vtkSmartPointer<vtkImageSliceMapper> mapper;
+    vtkSmartPointer<vtkImageSlice> image;
+    vtkSmartPointer<vtkImageProperty> imageProperty;
+    vtkRenderer* renderer;
+    int numberOfImages;
+    int currentImageIndex;
+};
+
+RenderEngine2::ImageVisual::ImageVisual(ImageSet^ images)
+{
+    privates = new ImageVisualPrivates();
+
+    this->images = images;
+
+	privates->imageReader = ImageSetReaderFactory::Acquire(images);
+
+    numberOfImages = images->Slices->Count;
+    int width = images->Slices[0]->Width;
+    int height = images->Slices[0]->Height;
+
+    auto firstImage = images->Slices[0];
+
+    privates->image = vtkSmartPointer<vtkImageSlice>::New();
+    privates->mapper = vtkSmartPointer<vtkImageSliceMapper>::New();
+
+    privates->mapper->SetInputData(privates->imageReader->GetOutput());
+    privates->image->SetMapper(privates->mapper);
+
+    privates->imageProperty = vtkSmartPointer<vtkImageProperty>::New();
+    privates->imageProperty->SetInterpolationTypeToCubic();
+    privates->image->SetProperty(privates->imageProperty);
+
+    int index = (images->Slices->Count - 1) / 2;
+    SetImageIndex(index);
+
+    auto image = images->Slices[index];
+    if (image->DefaultWindowingAvailable)
+    {
+        privates->imageProperty->SetColorWindow(image->WindowWidth);
+        privates->imageProperty->SetColorLevel(image->WindowLevel);
+    }
+}
+
+RenderEngine2::ImageVisual::!ImageVisual()
+{
+    delete privates;
+	ImageSetReaderFactory::Release(images);
+}
+
+RenderEngine2::ImageVisual::~ImageVisual()
+{
+    this->!ImageVisual();
+}
+
+void RenderEngine2::ImageVisual::PreRender(ViewportRenderer^ viewport)
+{
+}
+
+void RenderEngine2::ImageVisual::AddTo(ViewportRenderer ^ viewport)
+{
+    privates->renderer = viewport->GetRenderer();
+    viewport->GetRenderer()->AddActor(privates->image);
+}
+
+void RenderEngine2::ImageVisual::RemoveFrom(ViewportRenderer ^ viewport)
+{
+    viewport->GetRenderer()->RemoveActor(privates->image);
+}
+
+double RenderEngine2::ImageVisual::GetWindowLevel()
+{
+    return privates->imageProperty->GetColorLevel();
+}
+
+double RenderEngine2::ImageVisual::GetWindowWidth()
+{
+    return privates->imageProperty->GetColorWindow();
+}
+
+void RenderEngine2::ImageVisual::SetWindowing(double level, double width)
+{
+    privates->imageProperty->SetColorLevel(level);
+    privates->imageProperty->SetColorWindow(width);
+	Invalidated();
+}
+
+int RenderEngine2::ImageVisual::GetImageIndex()
+{
+    return currentImageIndex;
+}
+
+int RenderEngine2::ImageVisual::GetNumberOfImages()
+{
+    return numberOfImages;
+}
+
+void RenderEngine2::ImageVisual::SetImageIndex(int index)
+{
+    currentImageIndex = index;
+    privates->mapper->SetSliceNumber(currentImageIndex);
+	Invalidated();
+}

--- a/dicom_viewer_winform/RenderEngine2/ImageVisual.h
+++ b/dicom_viewer_winform/RenderEngine2/ImageVisual.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "IVisual.h"
+
+#include <vtkImageSliceMapper.h>
+#include <vtkImageSlice.h>
+
+class ImageVisualPrivates;
+
+namespace RenderEngine2
+{
+    public ref class ImageVisual : public IVisual
+    {
+    public:
+        ImageVisual(ImageSet^ images);
+        !ImageVisual();
+        ~ImageVisual();
+
+		virtual void PreRender(ViewportRenderer^ viewport);
+
+        virtual void AddTo(ViewportRenderer ^ viewport);
+        virtual void RemoveFrom(ViewportRenderer ^ viewport);
+
+        double GetWindowLevel();
+        double GetWindowWidth();
+        void SetWindowing(double level, double width);
+
+        int GetImageIndex();
+        int GetNumberOfImages();
+        void SetImageIndex(int index);
+
+		virtual event System::Action ^ Invalidated;
+
+    private:
+        ImageVisualPrivates* privates;
+
+        ImageSet^ images;
+        int numberOfImages;
+        int currentImageIndex;
+    };
+}

--- a/dicom_viewer_winform/RenderEngine2/RenderEngine2.vcxproj
+++ b/dicom_viewer_winform/RenderEngine2/RenderEngine2.vcxproj
@@ -124,6 +124,15 @@
     <ClInclude Include="pch.h" />
     <ClInclude Include="RenderEngine2.h" />
     <ClInclude Include="Resource.h" />
+    <ClInclude Include="Conversions.h" />
+    <ClInclude Include="ImageSetReaderFactory.h" />
+    <ClInclude Include="ImageVisual.h" />
+    <ClInclude Include="IVisual.h" />
+    <ClInclude Include="SlabAxesVisual.h" />
+    <ClInclude Include="SlabVisual.h" />
+    <ClInclude Include="ViewportRenderer.h" />
+    <ClInclude Include="VolumeVisual.h" />
+    <ClInclude Include="vtkMemoryImageReader.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="AssemblyInfo.cpp" />
@@ -133,6 +142,15 @@
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
+        <ClCompile Include="Conversions.cpp" />
+    <ClCompile Include="ImageSetReaderFactory.cpp" />
+    <ClCompile Include="ImageVisual.cpp" />
+    <ClCompile Include="IVisual.cpp" />
+    <ClCompile Include="SlabAxesVisual.cpp" />
+    <ClCompile Include="SlabVisual.cpp" />
+    <ClCompile Include="ViewportRenderer.cpp" />
+    <ClCompile Include="VolumeVisual.cpp" />
+    <ClCompile Include="vtkMemoryImageReader.cpp" />
     <ClCompile Include="RenderEngine2.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/dicom_viewer_winform/RenderEngine2/RenderEngine2.vcxproj.filters
+++ b/dicom_viewer_winform/RenderEngine2/RenderEngine2.vcxproj.filters
@@ -24,6 +24,33 @@
     <ClInclude Include="pch.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
+    <ClInclude Include="Conversions.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="ImageSetReaderFactory.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="ImageVisual.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="IVisual.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="SlabAxesVisual.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="SlabVisual.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="ViewportRenderer.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="VolumeVisual.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="vtkMemoryImageReader.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="RenderEngine2.cpp">
@@ -33,6 +60,33 @@
       <Filter>소스 파일</Filter>
     </ClCompile>
     <ClCompile Include="pch.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
+    <ClCompile Include="Conversions.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
+    <ClCompile Include="ImageSetReaderFactory.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
+    <ClCompile Include="ImageVisual.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
+    <ClCompile Include="IVisual.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
+    <ClCompile Include="SlabAxesVisual.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
+    <ClCompile Include="SlabVisual.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
+    <ClCompile Include="ViewportRenderer.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
+    <ClCompile Include="VolumeVisual.cpp">
+      <Filter>소스 파일</Filter>
+    </ClCompile>
+    <ClCompile Include="vtkMemoryImageReader.cpp">
       <Filter>소스 파일</Filter>
     </ClCompile>
   </ItemGroup>

--- a/dicom_viewer_winform/RenderEngine2/SlabAxesVisual.cpp
+++ b/dicom_viewer_winform/RenderEngine2/SlabAxesVisual.cpp
@@ -1,0 +1,187 @@
+#include "SlabAxesVisual.h"
+#include <vtkSmartPointer.h>
+#include <vtkImageSlice.h>
+#include <vtkImageResliceMapper.h>
+#include <vtkPlane.h>
+#include <vtkCamera.h>
+#include <vtkTransform.h>
+#include <vtkProperty.h>
+#include <vtkMatrix4x4.h>
+#include <vtkPolyData.h>
+#include <vtkCellData.h>
+#include <vtkPolyLine.h>
+#include <vtkPropPicker.h>
+
+using namespace RenderEngine2;
+
+class RenderEngine2::SlabAxesVisualPrivates
+{
+public:
+	vtkSmartPointer<vtkPolyData> axesLinesPolyData;
+	vtkSmartPointer<vtkPoints> axesPoints;
+	vtkSmartPointer<vtkPolyLine> xAxisLine;
+	vtkSmartPointer<vtkPolyLine> yAxisLine;
+	vtkSmartPointer<vtkPolyLine> zAxisLine;
+	vtkSmartPointer<vtkCellArray> lines;
+	vtkRenderer* renderer;
+
+	vtkSmartPointer<vtkPolyDataMapper> axesLinesMapper;
+	vtkSmartPointer<vtkActor> axesLinesActor;
+};
+
+vtkSmartPointer<vtkPolyLine> createBox(const int offset)
+{
+	auto polyLine = vtkSmartPointer<vtkPolyLine>::New();
+	polyLine->GetPointIds()->SetNumberOfIds(8);
+	for (int i = 0; i < 4; i++)
+	{
+		polyLine->GetPointIds()->SetId(i * 2, offset + i);
+		polyLine->GetPointIds()->SetId(i * 2 + 1, offset + (i + 1) % 4);
+	}
+	return polyLine;
+}
+
+SlabAxesVisual::SlabAxesVisual(Entities::Space^ space, Plane hiddenPlane)
+{
+	this->privates = new SlabAxesVisualPrivates();
+	this->space = space;
+	this->hiddenPlane = hiddenPlane;
+	this->isHighlighted = false;
+
+	privates->axesLinesPolyData = vtkSmartPointer<vtkPolyData>::New();
+
+	privates->axesPoints = vtkSmartPointer<vtkPoints>::New();
+
+	const double halfSize = 250;
+	// X-Y plane
+	privates->axesPoints->InsertNextPoint(-halfSize, halfSize, 0);
+	privates->axesPoints->InsertNextPoint(halfSize, halfSize, 0);
+	privates->axesPoints->InsertNextPoint(halfSize, -halfSize, 0);
+	privates->axesPoints->InsertNextPoint(-halfSize, -halfSize, 0);
+
+	// Y-Z plane
+	privates->axesPoints->InsertNextPoint(0, -halfSize, halfSize);
+	privates->axesPoints->InsertNextPoint(0, halfSize, halfSize);
+	privates->axesPoints->InsertNextPoint(0, halfSize, -halfSize);
+	privates->axesPoints->InsertNextPoint(0, -halfSize, -halfSize);
+
+	// X-Z plane
+	privates->axesPoints->InsertNextPoint(-halfSize, 0, halfSize);
+	privates->axesPoints->InsertNextPoint(halfSize, 0, halfSize);
+	privates->axesPoints->InsertNextPoint(halfSize, 0, -halfSize);
+	privates->axesPoints->InsertNextPoint(-halfSize, 0, -halfSize);
+
+	privates->axesLinesPolyData->SetPoints(privates->axesPoints);
+
+	privates->xAxisLine = createBox(0);
+	privates->yAxisLine = createBox(4);
+	privates->zAxisLine = createBox(8);
+
+	unsigned char red[3] = { 211, 54, 130 };
+	unsigned char green[3] = { 133, 153, 0 };
+	unsigned char blue[3] = { 88, 110, 117 };
+
+	vtkSmartPointer<vtkUnsignedCharArray> colors =
+		vtkSmartPointer<vtkUnsignedCharArray>::New();
+	colors->SetNumberOfComponents(3);
+
+	privates->lines = vtkSmartPointer<vtkCellArray>::New();
+	if (hiddenPlane != Plane::XY)
+	{
+		colors->InsertNextTypedTuple(red);
+		privates->lines->InsertNextCell(privates->xAxisLine);
+	}
+
+	if (hiddenPlane != Plane::YZ)
+	{
+		colors->InsertNextTypedTuple(green);
+		privates->lines->InsertNextCell(privates->yAxisLine);
+	}
+
+	if (hiddenPlane != Plane::XZ)
+	{
+		colors->InsertNextTypedTuple(blue);
+		privates->lines->InsertNextCell(privates->zAxisLine);
+	}
+
+	privates->axesLinesPolyData->SetLines(privates->lines);
+	privates->axesLinesPolyData->GetCellData()->SetScalars(colors);
+
+	privates->axesLinesMapper = vtkSmartPointer<vtkPolyDataMapper>::New();
+	privates->axesLinesMapper->SetInputData(privates->axesLinesPolyData);
+
+	privates->axesLinesActor = vtkSmartPointer<vtkActor>::New();
+	privates->axesLinesActor->SetMapper(privates->axesLinesMapper);
+	privates->axesLinesActor->GetProperty()->SetLineWidth(1.5);
+
+	vtkMapper::SetResolveCoincidentTopologyToPolygonOffset();
+	vtkMapper::SetResolveCoincidentTopologyPolygonOffsetParameters(0.1, 1);
+}
+
+SlabAxesVisual::!SlabAxesVisual()
+{
+	delete privates;
+}
+
+SlabAxesVisual::~SlabAxesVisual()
+{
+	this->!SlabAxesVisual();
+}
+
+bool RenderEngine2::SlabAxesVisual::Pick(double x, double y)
+{
+	auto picker = vtkSmartPointer<vtkPropPicker>::New();
+	picker->Pick(x, y, 0, privates->renderer);
+
+	bool isHit = picker->GetActor() == privates->axesLinesActor;
+	return isHit;
+}
+
+void RenderEngine2::SlabAxesVisual::Highlight()
+{
+	if (isHighlighted) { return; }
+	isHighlighted = true;
+	privates->axesLinesActor->GetProperty()->SetLineWidth(4);
+	Invalidated();
+}
+
+void RenderEngine2::SlabAxesVisual::DeHighlight()
+{
+	if (!isHighlighted) { return; }
+	isHighlighted = false;
+	privates->axesLinesActor->GetProperty()->SetLineWidth(2);
+	Invalidated();
+}
+
+void SlabAxesVisual::PreRender(ViewportRenderer ^ viewport)
+{
+	auto matrix = space->GetTransformationToRoot();
+
+	auto camera = viewport->GetRenderer()->GetActiveCamera();
+	double* direction = camera->GetDirectionOfProjection();
+	auto v = gcnew Vector3(direction[0], direction[1], direction[2]) * -10;
+
+	auto offsettedTransform = Matrix::Translation(v) * matrix;
+
+	auto userMatrix = vtkSmartPointer<vtkMatrix4x4>::New();
+	for (int y = 0; y < 4; y++)
+	{
+		for (int x = 0; x < 4; x++)
+		{
+			userMatrix->SetElement(x, y, offsettedTransform[y * 4 + x]);
+		}
+	}
+	privates->axesLinesActor->SetUserMatrix(userMatrix.Get());
+}
+
+void SlabAxesVisual::AddTo(ViewportRenderer ^ viewport)
+{
+	privates->renderer = viewport->GetRenderer();
+	privates->renderer->AddActor(privates->axesLinesActor);
+}
+
+void SlabAxesVisual::RemoveFrom(ViewportRenderer ^ viewport)
+{
+	privates->renderer = viewport->GetRenderer();
+	privates->renderer->RemoveActor(privates->axesLinesActor);
+}

--- a/dicom_viewer_winform/RenderEngine2/SlabAxesVisual.h
+++ b/dicom_viewer_winform/RenderEngine2/SlabAxesVisual.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "IVisual.h"
+
+namespace RenderEngine2 {
+	
+	class SlabAxesVisualPrivates;
+
+    public enum class Plane
+    {
+        XY,
+        YZ,
+        XZ,
+        None
+    };
+
+	public ref class SlabAxesVisual : public IVisual
+	{
+	public:
+		SlabAxesVisual(Entities::Space^ space, Plane hiddenPlane);
+		!SlabAxesVisual();
+		~SlabAxesVisual();
+
+        bool Pick(double x, double y);
+		void Highlight();
+		void DeHighlight();
+
+		virtual void PreRender(ViewportRenderer^ viewport);
+		virtual void AddTo(ViewportRenderer ^ viewport);
+		virtual void RemoveFrom(ViewportRenderer ^ viewport);
+		virtual event System::Action ^ Invalidated;
+	private:
+		SlabAxesVisualPrivates* privates;	
+		Entities::Space^ space;
+        Plane hiddenPlane;
+		bool isHighlighted;
+	};
+}

--- a/dicom_viewer_winform/RenderEngine2/SlabVisual.cpp
+++ b/dicom_viewer_winform/RenderEngine2/SlabVisual.cpp
@@ -1,0 +1,121 @@
+#include "SlabVisual.h"
+
+#include "vtkMemoryImageReader.h"
+#include <vtkCamera.h>
+#include <vtkSmartPointer.h>
+#include <vtkImageSlice.h>
+#include <vtkImageResliceMapper.h>
+#include <vtkPlane.h>
+#include <vtkImageProperty.h>
+#include <vtkMatrix4x4.h>
+#include <vtkPolyData.h>
+#include <vtkCellData.h>
+#include <vtkLine.h>
+#include "ImageSetReaderFactory.h"
+
+class RenderEngine2::SlabVisualPrivates 
+{
+public:
+	vtkMemoryImageReader* imageReader;
+	vtkSmartPointer<vtkImageResliceMapper> mapper;
+	vtkSmartPointer<vtkImageSlice> imageSlice;
+	vtkSmartPointer<vtkImageProperty> imageProperty;
+};
+
+RenderEngine2::SlabVisual::SlabVisual(Entities::ImageSet ^ images)
+{
+	privates = new SlabVisualPrivates();
+
+	this->images = images;
+
+	privates->imageReader = ImageSetReaderFactory::Acquire(images);
+	
+	privates->imageSlice = vtkSmartPointer<vtkImageSlice>::New();
+	privates->mapper = vtkSmartPointer<vtkImageResliceMapper>::New();
+
+	privates->mapper->SetInputData(privates->imageReader->GetOutput());
+	privates->imageSlice->SetMapper(privates->mapper);
+
+	privates->imageProperty = vtkSmartPointer<vtkImageProperty>::New();
+	privates->imageProperty->SetInterpolationTypeToCubic();	
+	privates->imageProperty->SetColorWindow(2000);
+	privates->imageProperty->SetColorLevel(500);
+
+	privates->imageSlice->SetProperty(privates->imageProperty);
+
+	privates->mapper->SetSlabTypeToMax();
+	privates->mapper->SliceFacesCameraOn();
+	privates->mapper->SliceAtFocalPointOn();
+	privates->mapper->AutoAdjustImageQualityOff();
+	privates->mapper->SetSlabSampleFactor(1);
+
+	auto rotation = images->TransformationToPatient;
+	auto position = images->Slices[0]->PositionPatient;
+	auto transform = Matrix::Translation(position) * rotation;
+
+	vtkSmartPointer<vtkMatrix4x4> userMatrix = vtkSmartPointer<vtkMatrix4x4>::New();
+	for (int y = 0; y < 4; y++)
+	{
+		for (int x = 0; x < 4; x++)
+		{
+			userMatrix->SetElement(x, y, transform[y * 4 + x]);
+		}
+	}
+	privates->imageSlice->SetUserMatrix(userMatrix);
+}
+
+void RenderEngine2::SlabVisual::PreRender(ViewportRenderer^ viewport)
+{
+
+}
+
+void RenderEngine2::SlabVisual::AddTo(ViewportRenderer ^ viewport)
+{
+	auto renderer = viewport->GetRenderer();
+	renderer->AddViewProp(privates->imageSlice);
+}
+
+void RenderEngine2::SlabVisual::RemoveFrom(ViewportRenderer ^ viewport)
+{
+	auto renderer = viewport->GetRenderer();
+	renderer->RemoveViewProp(privates->imageSlice);
+}
+
+double RenderEngine2::SlabVisual::GetWindowLevel()
+{
+	return privates->imageProperty->GetColorLevel();
+}
+
+double RenderEngine2::SlabVisual::GetWindowWidth()
+{
+	return privates->imageProperty->GetColorWindow();
+}
+
+void RenderEngine2::SlabVisual::SetWindowing(double level, double width)
+{
+	privates->imageProperty->SetColorLevel(level);
+	privates->imageProperty->SetColorWindow(width);
+	Invalidated();
+}
+
+double RenderEngine2::SlabVisual::GetSlabThickness()
+{
+	return privates->mapper->GetSlabThickness();
+}
+
+void RenderEngine2::SlabVisual::SetSlabThickness(double thicknessInMM)
+{
+	privates->mapper->SetSlabThickness(thicknessInMM);
+	Invalidated();
+}
+
+RenderEngine2::SlabVisual::!SlabVisual()
+{
+	delete privates;
+	ImageSetReaderFactory::Release(images);
+}
+
+RenderEngine2::SlabVisual::~SlabVisual()
+{
+	this->!SlabVisual();
+}

--- a/dicom_viewer_winform/RenderEngine2/SlabVisual.h
+++ b/dicom_viewer_winform/RenderEngine2/SlabVisual.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "ViewportRenderer.h"
+#include "IVisual.h"
+
+namespace RenderEngine2
+{
+	class SlabVisualPrivates;
+
+	public ref class SlabVisual: public IVisual
+	{
+	public:
+		SlabVisual(Entities::ImageSet^ images);
+		!SlabVisual();
+		~SlabVisual();
+
+		double GetWindowLevel();
+		double GetWindowWidth();
+		void SetWindowing(double level, double width);
+
+		double GetSlabThickness();
+		void SetSlabThickness(double thicknessInMM);
+
+		virtual void PreRender(ViewportRenderer^ viewport);
+		virtual void AddTo(ViewportRenderer ^ viewport);
+		virtual void RemoveFrom(ViewportRenderer ^ viewport);
+		virtual event System::Action ^ Invalidated;
+	private: 
+		SlabVisualPrivates* privates;
+		Entities::ImageSet^ images;		
+	};
+
+}

--- a/dicom_viewer_winform/RenderEngine2/ViewportRenderer.cpp
+++ b/dicom_viewer_winform/RenderEngine2/ViewportRenderer.cpp
@@ -1,0 +1,174 @@
+#include <Windows.h>
+#include "ViewportRenderer.h"
+#include <algorithm>
+#include "Conversions.h"
+
+#include <vtkAutoInit.h>
+VTK_MODULE_INIT(vtkRenderingOpenGL2)
+VTK_MODULE_INIT(vtkRenderingVolumeOpenGL2)
+
+#include <vtkWin32OpenGLRenderWindow.h>
+#include <vtkWindowToImageFilter.h>
+#include <vtkSphereSource.h>
+#include <vtkWin32OutputWindow.h>
+#include <vtkCamera.h>
+#include <vtkCoordinate.h>
+
+#define VTI_FILETYPE 1
+#define MHA_FILETYPE 2
+
+using namespace RenderEngine2;
+using namespace System::Data::Linq;
+
+class RenderEngine2::ViewportRendererImpl
+{
+public:
+    ViewportRendererImpl()
+		: renderWindow(vtkSmartPointer<vtkRenderWindow>::New())
+        , renderer(vtkSmartPointer<vtkOpenGLRenderer>::New())
+		, windowToImageFilter(vtkSmartPointer<vtkWindowToImageFilter>::New())
+    {
+        /*vtkSmartPointer<vtkWin32OutputWindow> outputWindow = vtkSmartPointer<vtkWin32OutputWindow>::New();
+        outputWindow->SetSendToStdErr(true);
+        vtkOutputWindow::SetInstance(outputWindow);*/
+        
+        renderWindow->AddRenderer(this->renderer);
+        renderWindow->DebugOn();
+
+        renderWindow->SetOffScreenRendering(true);
+
+        renderWindow->SetSize(400, 400);
+
+        windowToImageFilter->SetInputBufferTypeToRGBA();
+        windowToImageFilter->SetInput(this->renderWindow);
+
+        vtkCamera* camera = renderer->GetActiveCamera();
+        camera->ParallelProjectionOn();
+        camera->SetParallelScale(100);
+    }
+
+    ~ViewportRendererImpl()
+    {
+        windowToImageFilter = nullptr;
+        renderWindow = nullptr;
+        renderer = nullptr;
+    }
+  
+    void SetSize(int width, int height)
+    {
+        renderWindow->SetSize(width, height);
+    }
+
+    void SetCameraTransformation(double up[3], double position[3], double focalPoint[3])
+    {
+        vtkCamera* camera = renderer->GetActiveCamera();
+        camera->SetViewUp(up[0], up[1], up[2]);
+        camera->SetPosition(position[0], position[1], position[2]);
+        camera->SetFocalPoint(focalPoint[0], focalPoint[1], focalPoint[2]);
+    }
+
+    void SetZoom(double factor)
+    {
+        vtkCamera *camera = renderer->GetActiveCamera();
+        camera->SetParallelScale(factor);
+    }
+
+    void Render(byte* pixelData)
+    {
+        renderWindow->Render();
+
+        windowToImageFilter->Modified();
+        windowToImageFilter->Update();
+
+        vtkImageData* imageData = windowToImageFilter->GetOutput();
+        int width = imageData->GetDimensions()[0];
+        int height = imageData->GetDimensions()[1];
+
+        unsigned char *colorsPtr =
+            reinterpret_cast<unsigned char *>(imageData->GetScalarPointer());
+
+        byte * currentRgbPtr = pixelData;
+        for (int y = 0; y < height; y++)
+        {
+            for (int x = 0; x < width; x++)
+            {
+                *currentRgbPtr++ = colorsPtr[2];
+                *currentRgbPtr++ = colorsPtr[1];
+                *currentRgbPtr++ = colorsPtr[0];
+                *currentRgbPtr++ = colorsPtr[3];
+                colorsPtr += 4;
+            }
+        }
+    }
+
+    vtkRenderer* GetRenderer()
+    {
+        return renderer.GetPointer();
+    }
+
+private:
+    vtkSmartPointer<vtkRenderWindow> renderWindow;
+    vtkSmartPointer<vtkOpenGLRenderer> renderer;
+    vtkSmartPointer<vtkWindowToImageFilter> windowToImageFilter;
+};
+
+RenderEngine2::ViewportRenderer::ViewportRenderer()
+{
+    impl = new ViewportRendererImpl();
+}
+
+RenderEngine2::ViewportRenderer::~ViewportRenderer()
+{
+    this->!ViewportRenderer();
+}
+
+RenderEngine2::ViewportRenderer::!ViewportRenderer()
+{
+    if (impl != nullptr)
+    {
+        delete impl;
+        impl = nullptr;
+    }
+}
+
+Vector3 ^ RenderEngine2::ViewportRenderer::GetPositionInWorld(double x, double y)
+{
+    vtkCoordinate* coordinate = vtkCoordinate::New();
+    coordinate->SetCoordinateSystemToDisplay();
+    coordinate->SetValue(x, y);
+
+    double* world = coordinate->GetComputedWorldValue(impl->GetRenderer());
+    return gcnew Vector3(world[0], world[1], world[2]);
+}
+
+void RenderEngine2::ViewportRenderer::Render(IntPtr pixelData)
+{
+    impl->Render((byte*)pixelData.ToPointer());
+}
+
+void RenderEngine2::ViewportRenderer::SetSize(int width, int height)
+{
+    impl->SetSize(width, height);
+}
+
+void RenderEngine2::ViewportRenderer::SetZoom(double factor)
+{
+    impl->SetZoom(factor);
+}
+
+void RenderEngine2::ViewportRenderer::SetCameraTransformation(Matrix ^ transformation)
+{
+    Vector3^ position = transformation * gcnew Vector3(0, 0, 0);
+    Vector3^ direction = transformation * gcnew Vector3(0, 0, -400);
+    Vector3^ up = (transformation * gcnew Vector3(0, 1, 0)) + -position;
+
+    double upArr[3] = { up->X, up->Y, up->Z };
+    double positionArr[3] = { direction->X, direction->Y, direction->Z };
+    double focalPointArr[3]{ position->X, position->Y, position->Z };
+    impl->SetCameraTransformation(upArr, positionArr, focalPointArr);
+}
+
+vtkRenderer * RenderEngine2::ViewportRenderer::GetRenderer()
+{
+    return impl->GetRenderer();
+}

--- a/dicom_viewer_winform/RenderEngine2/ViewportRenderer.h
+++ b/dicom_viewer_winform/RenderEngine2/ViewportRenderer.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <vtkSphereSource.h>
+#include <vtkOpenGLPolyDataMapper.h>
+#include <vtkRenderWindow.h>
+#include <vtkRenderWindowInteractor.h>
+#include <vtkOpenGLRenderer.h>
+#include <vtkOpenGLActor.h>
+#include <vtkWindowToImageFilter.h>
+
+using namespace System;
+using namespace Entities;
+
+namespace RenderEngine2 {
+
+	class ViewportRendererImpl;
+
+	public ref class ViewportRenderer: IDisposable
+    {
+    public:
+		ViewportRenderer();
+		~ViewportRenderer();
+		!ViewportRenderer();
+
+        Vector3^ GetPositionInWorld(double x, double y);
+
+        void Render(IntPtr pixelData);
+        void SetSize(int width, int height);
+        void SetZoom(double factor);        
+        void SetCameraTransformation(Matrix^ matrix);
+	internal:
+		vtkRenderer* GetRenderer();
+
+    private:
+		ViewportRendererImpl* impl;
+    };
+}

--- a/dicom_viewer_winform/RenderEngine2/VolumeVisual.cpp
+++ b/dicom_viewer_winform/RenderEngine2/VolumeVisual.cpp
@@ -1,0 +1,182 @@
+#include "VolumeVisual.h"
+
+#include <vtkOpenGLGPUVolumeRayCastMapper.h>
+#include <vtkColorTransferFunction.h>
+#include <vtkPiecewiseFunction.h>
+#include <vtkMatrix4x4.h>
+#include <vtkVolumeProperty.h>
+#include "vtkMemoryImageReader.h"
+#include <vtkImageHistogram.h>
+#include "ImageSetReaderFactory.h"
+
+using namespace RenderEngine2;
+
+struct RenderEngine2::VolumeVisualPrivates
+{
+    double windowWidth = 360;
+    double windowLevel = 310;
+
+
+	vtkMemoryImageReader* reader;
+    vtkSmartPointer<vtkVolume> volume;
+    vtkSmartPointer<vtkOpenGLGPUVolumeRayCastMapper> mapper;
+    vtkSmartPointer<vtkColorTransferFunction> volumeColor;
+    vtkSmartPointer<vtkPiecewiseFunction> volumeScalarOpacity;
+    vtkSmartPointer<vtkVolumeProperty> volumeProperty;
+    vtkSmartPointer<vtkImageHistogram> histogram;
+};
+
+
+VolumeVisual::VolumeVisual(ImageSet ^ volumeData)
+    : privates(new VolumeVisualPrivates())
+{
+	images = volumeData;
+
+	privates->reader = ImageSetReaderFactory::Acquire(volumeData);
+    
+    privates->volume = vtkSmartPointer<vtkVolume>::New();
+    privates->mapper = vtkSmartPointer<vtkOpenGLGPUVolumeRayCastMapper>::New();
+	privates->mapper->AutoAdjustSampleDistancesOff();
+
+    privates->mapper->SetInputConnection(privates->reader->GetOutputPort());
+    privates->mapper->AutoAdjustSampleDistancesOff();
+    privates->mapper->SetSampleDistance(0.5);
+
+    privates->volumeColor =
+        vtkSmartPointer<vtkColorTransferFunction>::New();
+
+    privates->volumeColor->AddRGBPoint(-2024, 0, 0, 0, 0.5, 0.0);
+    privates->volumeColor->AddRGBPoint(-16, 0.73, 0.25, 0.30, 0.49, .61);
+    privates->volumeColor->AddRGBPoint(641, .90, .82, .56, .5, 0.0);
+    privates->volumeColor->AddRGBPoint(3071, 1, 1, 1, .5, 0.0);
+
+    // The opacity transfer function is used to control the opacity
+    // of different tissue types.
+    privates->volumeScalarOpacity = vtkSmartPointer<vtkPiecewiseFunction>::New();
+    //volumeScalarOpacity->AddPoint(1150, 0.85);
+
+    //volumeScalarOpacity->AddPoint(-3024, 0, 0.5, 0.0);
+    //volumeScalarOpacity->AddPoint(-16, 0, .49, .61);
+    //volumeScalarOpacity->AddPoint(641, .72, .5, 0.0);
+    //volumeScalarOpacity->AddPoint(3071, .71, 0.5, 0.0);
+
+    // The gradient opacity function is used to decrease the opacity
+    // in the "flat" regions of the volume while maintaining the opacity
+    // at the boundaries between tissue types.  The gradient is measured
+    // as the amount by which the intensity changes over unit distance.
+    // For most medical data, the unit distance is 1mm.
+    vtkSmartPointer<vtkPiecewiseFunction> volumeGradientOpacity =
+        vtkSmartPointer<vtkPiecewiseFunction>::New();
+    volumeGradientOpacity->AddPoint(0, 0.0);
+    volumeGradientOpacity->AddPoint(50, 0.5);
+    volumeGradientOpacity->AddPoint(100, 1.0);
+
+    privates->volumeProperty = vtkSmartPointer<vtkVolumeProperty>::New();
+
+    privates->volumeProperty->SetColor(privates->volumeColor);
+
+    privates->volumeProperty->SetScalarOpacity(privates->volumeScalarOpacity);
+    privates->volumeProperty->SetGradientOpacity(volumeGradientOpacity);
+    privates->volumeProperty->SetInterpolationTypeToLinear();
+    privates->volumeProperty->ShadeOn();
+    privates->volumeProperty->SetAmbient(0.1);
+    privates->volumeProperty->SetDiffuse(0.8);
+    privates->volumeProperty->SetSpecular(0.2);
+    privates->volumeProperty->GetSpecularPower(50);
+    privates->volumeProperty->SetScalarOpacityUnitDistance(0.8919);
+
+    privates->volume->SetProperty(privates->volumeProperty);
+    privates->volume->SetMapper(privates->mapper);
+
+    auto rotation = volumeData->TransformationToPatient;
+    auto position = volumeData->Slices[0]->PositionPatient;
+    auto transform = Matrix::Translation(position) * rotation;
+
+    vtkSmartPointer<vtkMatrix4x4> userMatrix = vtkSmartPointer<vtkMatrix4x4>::New();
+    for (int y = 0; y < 4; y++)
+    {
+        for (int x = 0; x < 4; x++)
+        {
+            userMatrix->SetElement(x, y, transform[y * 4 + x]);
+        }
+    }
+    privates->volume->SetUserMatrix(userMatrix);
+
+    SetWindowing(1000, 2000);
+
+    privates->histogram =
+        vtkSmartPointer<vtkImageHistogram>::New();
+    privates->histogram->SetInputConnection(privates->reader->GetOutputPort());
+}
+
+VolumeVisual::~VolumeVisual()
+{
+    this->!VolumeVisual();
+}
+
+RenderEngine2::VolumeVisual::!VolumeVisual()
+{
+    delete privates;
+	ImageSetReaderFactory::Release(images);
+}
+
+void RenderEngine2::VolumeVisual::PreRender(ViewportRenderer ^ viewport)
+{
+}
+
+void VolumeVisual::AddTo(ViewportRenderer ^ viewport)
+{
+    viewport->GetRenderer()->AddVolume(privates->volume);
+}
+
+void RenderEngine2::VolumeVisual::RemoveFrom(ViewportRenderer ^ viewport)
+{
+    viewport->GetRenderer()->RemoveVolume(privates->volume);
+}
+
+array<long>^ RenderEngine2::VolumeVisual::GetHistogram()
+{
+    privates->histogram->GenerateHistogramImageOff();
+    privates->histogram->AutomaticBinningOff();
+    privates->histogram->Update();
+
+    vtkIdType nbins = privates->histogram->GetNumberOfBins();
+    double range[2];
+    range[0] = privates->histogram->GetBinOrigin();
+    range[1] = range[0] + (nbins - 1)*privates->histogram->GetBinSpacing();
+
+    vtkIdTypeArray* output = privates->histogram->GetHistogram();
+    const long nrValues = output->GetNumberOfValues();
+    auto result = gcnew array<long>(nrValues);
+    for (int i = 1; i < nrValues - 1; i++)
+    {
+        result[i] = Math::Sqrt(output->GetValue(i));
+    }
+    return result;
+}
+
+void VolumeVisual::SetWindowing(double windowLevel, double windowWidth)
+{
+    privates->windowLevel = windowLevel;
+    privates->windowWidth = windowWidth;
+
+    privates->volumeScalarOpacity->RemoveAllPoints();
+
+    double min = windowLevel - windowWidth / 2;
+    double max = windowLevel + windowWidth / 2;
+    privates->volumeScalarOpacity->AddPoint(-2000, 0.00, 0.5, 0);
+    privates->volumeScalarOpacity->AddPoint(min, 0.0, 0.5, 0.5);
+    privates->volumeScalarOpacity->AddPoint(max, 1, 0.5, 0);
+
+    Invalidated();
+}
+
+double RenderEngine2::VolumeVisual::GetWindowLevel()
+{
+    return privates->windowLevel;
+}
+
+double RenderEngine2::VolumeVisual::GetWindowWidth()
+{
+    return privates->windowWidth;
+}

--- a/dicom_viewer_winform/RenderEngine2/VolumeVisual.h
+++ b/dicom_viewer_winform/RenderEngine2/VolumeVisual.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "ViewportRenderer.h"
+#include "IVisual.h"
+
+namespace RenderEngine2 
+{
+	using namespace Entities;
+
+	struct VolumeVisualPrivates;
+
+	public ref class VolumeVisual: public IVisual
+	{
+	public:
+		VolumeVisual(ImageSet^ volumeData);
+		~VolumeVisual();
+		!VolumeVisual();
+
+		virtual void PreRender(ViewportRenderer^ viewport);
+		virtual void AddTo(ViewportRenderer ^ viewport);
+		virtual void RemoveFrom(ViewportRenderer ^ viewport);
+
+		array<long>^ GetHistogram();
+		void SetWindowing(double windowLevel, double windowWidth);
+		double GetWindowLevel();
+		double GetWindowWidth();
+		virtual event System::Action ^ Invalidated;
+	private:
+		VolumeVisualPrivates* privates;
+		ImageSet^ images;
+	};
+
+}

--- a/dicom_viewer_winform/RenderEngine2/vtkMemoryImageReader.cpp
+++ b/dicom_viewer_winform/RenderEngine2/vtkMemoryImageReader.cpp
@@ -1,0 +1,137 @@
+#include "vtkMemoryImageReader.h"
+
+#include "vtkImageData.h"
+
+#include "vtkByteSwap.h"
+#include "vtkDataArray.h"
+#include "vtkImageData.h"
+#include "vtkInformation.h"
+#include "vtkInformationVector.h"
+#include "vtkObjectFactory.h"
+#include "vtkPointData.h"
+#include "vtkErrorCode.h"
+#include "vtkStringArray.h"
+#include <vtkStreamingDemandDrivenPipeline.h>
+#include "vtksys/SystemTools.hxx"
+
+#include <Windows.h>
+
+vtkStandardNewMacro(vtkMemoryImageReader);
+
+vtkMemoryImageReader::vtkMemoryImageReader()
+    : images(nullptr)
+    , bytesPerPixel(1)
+    , width(0)
+    , height(0)
+    , numberOfImages(0)
+    , rescaleIntercept(0)
+    , rescaleSlope(1)
+    , pixelSpacingX(1)
+    , pixelSpacingY(1)
+    , pixelSpacingZ(1)
+    , isSigned(false)
+{
+    this->SetNumberOfInputPorts(0);
+}
+
+
+vtkMemoryImageReader::~vtkMemoryImageReader()
+{
+}
+
+void vtkMemoryImageReader::SetImages(
+    void ** images,
+    int bytesPerPixel,
+    int width,
+    int height,
+    int numberOfImages,
+    double rescaleIntercept,
+    double rescaleSlope,
+    double pixelSpacingX,
+    double pixelSpacingY,
+    double pixelSpacingZ,
+    bool isSigned)
+{
+    this->images = images;
+    this->bytesPerPixel = bytesPerPixel;
+    this->width = width;
+    this->height = height;
+    this->numberOfImages = numberOfImages;
+    this->rescaleIntercept = rescaleIntercept;
+    this->rescaleSlope = rescaleSlope;
+    this->pixelSpacingX = pixelSpacingX;
+    this->pixelSpacingY = pixelSpacingY;
+    this->pixelSpacingZ = pixelSpacingZ;
+    this->isSigned = isSigned;
+}
+
+int vtkMemoryImageReader::RequestUpdateExtent(vtkInformation *, vtkInformationVector ** inputVector, vtkInformationVector * outputVector)
+{
+    return 1;
+}
+
+int vtkMemoryImageReader::RequestData(vtkInformation *, vtkInformationVector **, vtkInformationVector * outputVector)
+{
+    vtkInformation *outInfo = outputVector->GetInformationObject(0);
+    vtkImageData *output = vtkImageData::SafeDownCast(
+        outInfo->Get(vtkDataObject::DATA_OBJECT()));
+
+    this->Execute(output);
+
+    return 1;
+}
+
+void vtkMemoryImageReader::Execute(vtkImageData * output)
+{
+    output->SetDimensions(width, height, numberOfImages);
+    output->SetSpacing(pixelSpacingX, pixelSpacingY, pixelSpacingZ);
+    output->SetOrigin(0, 0, 0);
+    output->SetNumberOfScalarComponents(1, GetOutputInformation(0));
+    output->SetExtent(0, width - 1, 0, height - 1, 0, numberOfImages - 1);
+    output->SetScalarType(VTK_SHORT, GetOutputInformation(0));
+    output->AllocateScalars(VTK_SHORT, 1);
+
+    short* p = (short*)output->GetScalarPointer();
+    if (bytesPerPixel == 2 && !isSigned)
+    {
+        Copy<unsigned short>((unsigned short**)images, p);
+    }
+    else if (bytesPerPixel == 1 && !isSigned)
+    {
+        Copy<unsigned char>((unsigned char**)images, p);
+    }
+    else if (bytesPerPixel == 2 && isSigned)
+    {
+        Copy<short>((short**)images, p);
+    }
+    else if (bytesPerPixel == 1 && isSigned)
+    {
+        Copy<char>((char**)images, p);
+    }
+
+    output->Modified();
+}
+
+template<typename T>
+inline void vtkMemoryImageReader::Copy(T ** slices, short * destination)
+{
+    short* p = destination;
+    for (int y = 0; y < numberOfImages; y++)
+    {
+        for (int z = 0; z < height; z++)
+        {
+            for (int x = 0; x < width; x++)
+            {
+                long offset = z * width + x;
+                long storedValue;
+                storedValue = ((long) *((T*)images[y] + offset));
+                *p++ = (short)(rescaleSlope * storedValue) + rescaleIntercept;
+            }
+        }
+    }
+
+    HANDLE hFile = CreateFile(L"d:\\temp\\temp1.dat", GENERIC_ALL, FILE_SHARE_WRITE, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+    DWORD dwWritten;
+    WriteFile(hFile, destination, numberOfImages * height * width * sizeof(T), &dwWritten, NULL);
+    CloseHandle(hFile);
+}

--- a/dicom_viewer_winform/RenderEngine2/vtkMemoryImageReader.h
+++ b/dicom_viewer_winform/RenderEngine2/vtkMemoryImageReader.h
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <vtkSimpleImageToImageFilter.h>
+
+class vtkMemoryImageReader : public vtkImageAlgorithm
+{
+public:
+    static vtkMemoryImageReader *New();
+    vtkTypeMacro(vtkMemoryImageReader, vtkImageAlgorithm);
+
+    vtkMemoryImageReader();
+    virtual ~vtkMemoryImageReader();
+
+    void SetImages(
+        void ** images,
+		int bytesPerPixel,
+        int width,
+        int height,
+        int numberOfImages,
+        double rescaleIntercept,
+        double rescaleSlope,
+        double pixelSpacingX,
+        double pixelSpacingY,
+        double pixelSpacingZ,
+        bool isSigned);
+
+    int RequestUpdateExtent(vtkInformation *,
+        vtkInformationVector **,
+        vtkInformationVector *) override;
+
+    int RequestData(vtkInformation *,
+        vtkInformationVector **,
+        vtkInformationVector *) override;
+
+    virtual void Execute(vtkImageData* output);
+
+private:
+    vtkMemoryImageReader(const vtkMemoryImageReader&) = delete;
+    void operator=(const vtkMemoryImageReader&) = delete;
+
+    template<typename T>
+    void Copy(T ** slices, short * destination);
+
+    void** images;
+	int bytesPerPixel;
+    int width;
+    int height;
+    int numberOfImages;
+    double rescaleIntercept;
+    double rescaleSlope;
+    double pixelSpacingX;
+    double pixelSpacingY;
+    double pixelSpacingZ;
+    bool isSigned;
+};

--- a/dicom_viewer_winform/dicom_viewer_winform.sln
+++ b/dicom_viewer_winform/dicom_viewer_winform.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "dicom_viewer_winform", "dic
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "RenderEngine", "RenderEngine\RenderEngine.vcxproj", "{052AFDD0-10BE-4B76-A594-01F778DFE8FF}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "RenderEngine2", "RenderEngine2\RenderEngine2.vcxproj", "{27D9BB1F-8298-CF70-8EF3-6BB6FBCF909F}"?
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Entities", "dicom_viewer_winform\Entities\Entities.csproj", "{197DD6A4-5EC4-4BA2-A8DF-078FE0C21303}"
 EndProject
 Global
@@ -33,6 +35,14 @@ Global
 		{052AFDD0-10BE-4B76-A594-01F778DFE8FF}.Release|Any CPU.Build.0 = Release|x64
 		{052AFDD0-10BE-4B76-A594-01F778DFE8FF}.Release|x64.ActiveCfg = Release|x64
                 {052AFDD0-10BE-4B76-A594-01F778DFE8FF}.Release|x64.Build.0 = Release|x64
+                {27D9BB1F-8298-CF70-8EF3-6BB6FBCF909F}.Debug|Any CPU.ActiveCfg = Debug|x64
+                {27D9BB1F-8298-CF70-8EF3-6BB6FBCF909F}.Debug|Any CPU.Build.0 = Debug|x64
+                {27D9BB1F-8298-CF70-8EF3-6BB6FBCF909F}.Debug|x64.ActiveCfg = Debug|x64
+                {27D9BB1F-8298-CF70-8EF3-6BB6FBCF909F}.Debug|x64.Build.0 = Debug|x64
+                {27D9BB1F-8298-CF70-8EF3-6BB6FBCF909F}.Release|Any CPU.ActiveCfg = Release|x64
+                {27D9BB1F-8298-CF70-8EF3-6BB6FBCF909F}.Release|Any CPU.Build.0 = Release|x64
+                {27D9BB1F-8298-CF70-8EF3-6BB6FBCF909F}.Release|x64.ActiveCfg = Release|x64
+                {27D9BB1F-8298-CF70-8EF3-6BB6FBCF909F}.Release|x64.Build.0 = Release|x64
                 {197DD6A4-5EC4-4BA2-A8DF-078FE0C21303}.Debug|Any CPU.ActiveCfg = Debug|x64
                 {197DD6A4-5EC4-4BA2-A8DF-078FE0C21303}.Debug|x64.ActiveCfg = Debug|x64
                 {197DD6A4-5EC4-4BA2-A8DF-078FE0C21303}.Debug|x64.Build.0 = Debug|x64

--- a/dicom_viewer_winform/dicom_viewer_winform/dicom_viewer_winform.csproj
+++ b/dicom_viewer_winform/dicom_viewer_winform/dicom_viewer_winform.csproj
@@ -24,7 +24,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\RenderEngine\RenderEngine.vcxproj" />
+    <ProjectReference Include="..\RenderEngine2\RenderEngine2.vcxproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- copy RenderEngine sources into the new RenderEngine2 project
- update namespace usages
- include RenderEngine2 in the solution and reference it from the WinForms project

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864da823fc8832f9a7bd6ac66dba39d